### PR TITLE
Fixing sick uris

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,11 +45,13 @@ module ApplicationHelper
 
 
   def show_scaled_image(doc, opts)
+    uri2 = CGI.escape(doc['thumbnail_url_ssm'].first)
     uri = doc['thumbnail_url_ssm'].first
     if uri[/ull\/[^\/]*?/]
       uri = uri.gsub(/full\/[^\/]*?\//,'full/!225,/')
     end
-    img_tag = image_tag(URI(uri))
+    img_tag2 = image_tag(URI(uri2))
+    img_tag = image_tag(uri)
     return img_tag
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,12 +45,11 @@ module ApplicationHelper
 
 
   def show_scaled_image(doc, opts)
-    uri2 = CGI.escape(doc['thumbnail_url_ssm'].first)
     uri = doc['thumbnail_url_ssm'].first
     if uri[/ull\/[^\/]*?/]
       uri = uri.gsub(/full\/[^\/]*?\//,'full/!225,/')
     end
-    img_tag2 = image_tag(URI(uri2))
+    # what if uri is even sicker than having space?
     img_tag = image_tag(uri)
     return img_tag
   end


### PR DESCRIPTION
For some reasons blacklight dies while screaming when presenting navigation pages having thumb nails with spaces in the URI. Ignoring the problem whether URIs should have spaces in them, this patch fixes the problem.

This was done by David and myself.